### PR TITLE
Fix RTK Sender Example using QSerialPort and Add Resurvey Options

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,11 @@ project(rtk-sender-example CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
-find_package(MAVSDK REQUIRED)
+find_package(Qt5 COMPONENTS SerialPort REQUIRED)
+find_package(MAVSDK REQUIRED PATHS $ENV{HOME}/Work/Sees/BackupLink/MAVSDK/install)
 
 add_executable(rtk-sender-example
     rtk-sender-example.cpp
-    serial-comms.h
-    serial-comms.cpp
     definitions.h
     driver-interface.h
     driver-interface.cpp
@@ -30,6 +29,7 @@ target_compile_options(rtk-sender-example
 
 target_link_libraries(rtk-sender-example
     MAVSDK::mavsdk
+    Qt5::SerialPort
 )
 
 target_include_directories(rtk-sender-example

--- a/driver-interface.cpp
+++ b/driver-interface.cpp
@@ -53,5 +53,5 @@ void DriverInterface::send_rtcm_data(const uint8_t* data, int data_len)
     rtcm_data.data.insert(rtcm_data.data.end(), data, data + data_len);
     rtk_plugin_->send_rtcm_data(rtcm_data);
 
-    std::cout << "Fix type: " << telemetry_plugin_->gps_info().fix_type << '\n';
+    // std::cout << "Fix type: " << telemetry_plugin_->gps_info().fix_type << '\n';
 }

--- a/driver-interface.cpp
+++ b/driver-interface.cpp
@@ -10,17 +10,25 @@ int DriverInterface::callback_entry(GPSCallbackType type, void* data1, int data2
 int DriverInterface::callback(GPSCallbackType type, void* data1, int data2)
 {
     switch (type) {
-        case GPSCallbackType::readDeviceData:
-            return serial_comms_.read(static_cast<uint8_t*>(data1), data2);
-
+        case GPSCallbackType::readDeviceData: {
+            if (serial_comms_.bytesAvailable() == 0) {
+                int timeout = *((int *) data1);
+                if (!serial_comms_.waitForReadyRead(timeout))
+                    return 0;
+            }
+            return (int)serial_comms_.read((char*)data1, data2);
+        }
         case GPSCallbackType::writeDeviceData:
-            return serial_comms_.write(static_cast<const uint8_t*>(data1), data2);
-
+            if (serial_comms_.write(char*) data1, data2) >= 0) {
+                if (serial_comms_.waitForBytesWritten(-1))
+                    return data2;
+            }
+            return -1;
         case GPSCallbackType::setBaudrate:
-            return (serial_comms_.set_baudrate(data2) ? 0 : 1);
+            return serial_comms_.setBaudRate(data2) ? 0 : -1;
 
         case GPSCallbackType::gotRTCMMessage:
-            send_rtcm_data(static_cast<const uint8_t*>(data1), data2);
+            send_rtcm_data((uint8_t*)data1, data2);
             return 0;
 
         default:

--- a/driver-interface.cpp
+++ b/driver-interface.cpp
@@ -19,7 +19,7 @@ int DriverInterface::callback(GPSCallbackType type, void* data1, int data2)
             return (int)serial_comms_.read((char*)data1, data2);
         }
         case GPSCallbackType::writeDeviceData:
-            if (serial_comms_.write(char*) data1, data2) >= 0) {
+            if (serial_comms_.write((char*) data1, data2) >= 0) {
                 if (serial_comms_.waitForBytesWritten(-1))
                     return data2;
             }

--- a/driver-interface.h
+++ b/driver-interface.h
@@ -1,17 +1,17 @@
 #pragma once
 
 #include "definitions.h"
-#include "serial-comms.h"
 #include "gps_helper.h"
 
 #include <memory>
 #include <mavsdk/mavsdk.h>
 #include <mavsdk/plugins/rtk/rtk.h>
 #include <mavsdk/plugins/telemetry/telemetry.h>
+#include <QSerialPort>
 
 class DriverInterface {
 public:
-    DriverInterface(SerialComms& serial_comms, mavsdk::Mavsdk& mavsdk) :
+    DriverInterface(QSerialPort& serial_comms, mavsdk::Mavsdk& mavsdk) :
         serial_comms_(serial_comms),
         mavsdk_(mavsdk) {}
 
@@ -22,10 +22,10 @@ public:
     void send_rtcm_data(const uint8_t* data, int data_len);
 
     struct sensor_gps_s        gps_pos;
-	struct satellite_info_s    sat_info;
+    struct satellite_info_s    sat_info;
 
 private:
-    SerialComms& serial_comms_;
+    QSerialPort& serial_comms_;
     mavsdk::Mavsdk& mavsdk_;
     std::shared_ptr<mavsdk::Rtk> rtk_plugin_{};
     std::shared_ptr<mavsdk::Telemetry> telemetry_plugin_{};

--- a/rtk-sender-example.cpp
+++ b/rtk-sender-example.cpp
@@ -16,14 +16,14 @@ int main(int argc, char* argv[])
     printf("Starting rtk-sender-example sees.ai mod version v1.2\n");
     printf("Using PX4-GPSDrivers commit 93168099b4c17d2612a28d83ed15e6542a578920\n");
 
-    if (argc <= 7) {
+    if (argc < 7) {
         printf("\n");
         printf("usage: %s <serial device> <baudrate> <mavlink connection> <rtk mode> <mode params>\n", argv[0]);
         printf("Different rtk modes require different amount of parameters\n");
         printf("Mode \"Fixed\" needs three parameters: lat, lon, altitude(m)\n");
         printf("Mode \"Resurvey\" needs two parameters: duration(s), error(m)\n");
         printf("e.g.: rtk-sender-example /dev/ttyUSB0 38400 udp://:14550 Fixed 14.3666 0.4556 120\n" );
-        printf("e.g.: rtk-sender-example /dev/ttyUSB0 38400 udp://:14550 Resurvey 120 0.8\n" );
+        printf("e.g.: rtk-sender-example /dev/ttyUSB0 38400 udp://:14550 Resurvey 0.8 120\n" );
         printf("Note: use baudrate 0 to determine baudrate automatically\n");
         return 1;
     }

--- a/rtk-sender-example.cpp
+++ b/rtk-sender-example.cpp
@@ -43,7 +43,7 @@ int main(int argc, char* argv[])
             }
         }
         if (serial.error() != QSerialPort::NoError) {
-            std::cout << "GPS: Failed to open Serial Device" << argv[1] << ": " << serial.errorString();
+            std::cout << "GPS: Failed to open Serial Device " << argv[1] << ": " << serial.errorString().data() << std::endl;
             return 1;
         }
     }

--- a/rtk-sender-example.cpp
+++ b/rtk-sender-example.cpp
@@ -1,4 +1,5 @@
 #include <cstdio>
+#include <iostream>
 #include <memory>
 
 #include "PX4-GPSDrivers/src/gps_helper.h"
@@ -25,11 +26,6 @@ int main(int argc, char* argv[])
 
 
     unsigned baudrate = std::stoi(argv[2]);
-
-    SerialComms serial_comms;
-    if (!serial_comms.init(argv[1])) {
-        return 2;
-    }
     
     QSerialPort serial;
     serial.setPortName(argv[1]);
@@ -52,7 +48,7 @@ int main(int argc, char* argv[])
         }
     }
     
-    serial.setBaudrate(QSerialPort::Baud9600);
+    serial.setBaudRate(QSerialPort::Baud9600);
     serial.setDataBits(QSerialPort::Data8);
     serial.setParity(QSerialPort::NoParity);
     serial.setStopBits(QSerialPort::OneStop);


### PR DESCRIPTION
This PR fixes the RTK sender example RTCM data drop-outs by replicating the behaviour with QGC, i.e. using QSerialPort library.